### PR TITLE
Add Support For Multiple AuditRecord Elements

### DIFF
--- a/TmfReferenceModelExchange.xsd
+++ b/TmfReferenceModelExchange.xsd
@@ -223,7 +223,7 @@
                                         </xs:element>
 
                                         <!-- 5.3.5 <AUDITRECORD> Tag -->
-                                        <xs:element name="AUDITRECORD">
+                                        <xs:element name="AUDITRECORD" minOccurs="0" maxOccurs="unbounded">
                                             <xs:complexType>
                                                 <xs:sequence>
                                                     <!-- Attribute Format: Text -->


### PR DESCRIPTION
Hi there!

I made the following edit to the schema - thereby bringing it inline with the eTMF-EMS specification with regards to supporting multiple AuditRecord elements per File element.