### PR TITLE
Add multi objects definition

### DIFF
--- a/TmfReferenceModelExchange.xsd
+++ b/TmfReferenceModelExchange.xsd
@@ -66,7 +66,7 @@
         <xs:complexType>
             <xs:sequence>
                 <!-- Section 5.3.2 <OBJECT> Tag -->
-                <xs:element name="OBJECT">
+                <xs:element name="OBJECT" minOccurs="1" maxOccurs="unbounded">
                     <xs:complexType>
                         <xs:sequence>
                             <!-- Attribute Format: Text -->

--- a/TmfReferenceModelExchange.xsd
+++ b/TmfReferenceModelExchange.xsd
@@ -223,7 +223,7 @@
                                         </xs:element>
 
                                         <!-- 5.3.5 <AUDITRECORD> Tag -->
-                                        <xs:element name="AUDITRECORD">
+                                        <xs:element name="AUDITRECORD" minOccurs="0" maxOccurs="unbounded">
                                             <xs:complexType>
                                                 <xs:sequence>
                                                     <!-- Attribute Format: Text -->


### PR DESCRIPTION
The way the schema is currently designed, there is no way to add multiple Objects to a Batch. I have therefore modified it to support 1 or more. 

I have been leveraging Java's `xjc` utility for generating JAXB binding classes which is how I have begun noticing these limitations in the schema. 

If I am completely missing something, please go ahead and correct my misunderstanding. 

Chris D.