### PR TITLE
Change type of UNIQUEID from int to string.

### DIFF
--- a/TmfReferenceModelExchange.xsd
+++ b/TmfReferenceModelExchange.xsd
@@ -99,7 +99,7 @@
                             <!-- Attribute Format: Number on 3 digits i.e. 001, 010-->
                             <xs:element name="UNIQUEID">
                                 <xs:simpleType>
-                                    <xs:restriction base="xs:int">
+                                    <xs:restriction base="xs:string">
                                         <xs:pattern value="[0-9]{3}"/>
                                     </xs:restriction>
                                 </xs:simpleType>


### PR DESCRIPTION
Change type of UNIQUEID from int to string, to be able to set 3 digit values i.e 001, 010 to the model that is generated from xsd .