### PR TITLE
Let TMFRMVERSION accept values in format '1.0.0' (including patch version of ref model)

### DIFF
--- a/TmfReferenceModelExchange.xsd
+++ b/TmfReferenceModelExchange.xsd
@@ -272,11 +272,11 @@
             <!-- Attribute Format: Text (mandatory) -->
             <xs:attribute name="SPECIFICATIONID" type="nonEmptyString" use="required"/>
 
-            <!-- Attribute Format: Text (mandatory - supports 1.0 and 1.0.0 format) -->
+            <!-- Attribute Format: Text (mandatory - supports 1.0 and 1.0.0 format, no leading zeros are allowed e.g. 01.01.01) -->
             <xs:attribute name="TMFRMVERSION" use="required">
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
-                        <xs:pattern value="[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}|[0-9]{1,2}\.[0-9]{1,2}"/>
+                        <xs:pattern value="((([1-9][0-9])|([0-9]))\.(([1-9][0-9])|([0-9]))\.(([1-9][0-9])|([0-9])))|((([1-9][0-9])|([0-9]))\.(([1-9][0-9])|([0-9])))"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>

--- a/TmfReferenceModelExchange.xsd
+++ b/TmfReferenceModelExchange.xsd
@@ -272,9 +272,14 @@
             <!-- Attribute Format: Text (mandatory) -->
             <xs:attribute name="SPECIFICATIONID" type="nonEmptyString" use="required"/>
 
-            <!-- Attribute Format: Text (mandatory - 1.0, 2.0, 3.0 etc.)
-                 NOTE: we specify decimal as the data type, which supports 1.0 but not 1.0.0 -->
-            <xs:attribute name="TMFRMVERSION" type="xs:decimal" use="required"/>
+            <!-- Attribute Format: Text (mandatory - supports 1.0 and 1.0.0 format) -->
+            <xs:attribute name="TMFRMVERSION" use="required">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:pattern value="[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}|[0-9]{1,2}\.[0-9]{1,2}"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
 </xs:schema>


### PR DESCRIPTION
Since the latest version of ref model is 3.2.1, there is a need to have an ability to have a value for TMFRMVERSION field as '1.0.0' not only '1.0'. In the latest specification https://tmfrefmodel.com/wp-content/uploads/eTMF-EMS-Specification-v1.0.1.pdf TMFRMVERSION has a text type, not decimal.

Suggested regular expression validates input for '1.0.0' format but also supports '1.0' format for backward compatibility.